### PR TITLE
Add user role field to users table

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# The User class is responsible for manage the superadmin user
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -2,10 +2,6 @@
   <%= link_to "Log in", new_session_path(resource_name) %><br />
 <% end %>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end %>
-
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
-  devise_for :users
+  #For skipping the logic registration to users
+  devise_for :users, :skip => [:registrations] 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  #allow edit and update information fo users
+  as :user do
+    get 'users/edit' => 'devise/registrations#edit', :as => 'edit_user_registration'
+    put 'users' => 'devise/registrations#update', :as => 'user_registration'
+  end
   root 'static#index'
   namespace :v1, defaults: {format: 'json' } do
     get 'things', to: 'things#index'

--- a/db/migrate/20211004220835_devise_create_users.rb
+++ b/db/migrate/20211004220835_devise_create_users.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+# The DeviseCreateUsers migration create a users table for authentification mechanism
 class DeviseCreateUsers < ActiveRecord::Migration[6.1]
   def change
     create_table :users do |t|

--- a/db/migrate/20211006003056_add_role_to_users.rb
+++ b/db/migrate/20211006003056_add_role_to_users.rb
@@ -1,0 +1,8 @@
+# The AddRoleToUsers migration add superadmin and user role fields to users table for authorization process
+class AddRoleToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :superadmin_role, :boolean, default: false
+    add_column :users, :user_role, :boolean, default: true
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_04_220835) do
+ActiveRecord::Schema.define(version: 2021_10_06_003056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2021_10_04_220835) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "superadmin_role", default: false
+    t.boolean "user_role", default: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,30 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  before :all do 
+    @user_without_email = User.new(email: "example1@test.com")
+    @user_without_strong_password = User.new(email: "example2@test.com", password: "12345")
+    @user_strong_password = User.new(email: "example2@test.com", password: "123456")
+    @user_super_admin = User.create!(email: "example3@test.com", password: "123456", superadmin_role: true)
+    @user_no_user_role = User.create!(email: "example4@test.com", password: "123456", superadmin_role: true, user_role: false)
+  end
+  it "has a password empty field" do
+    expect(@user_without_email.save).to be_falsey 
+  end
+  it "has a password with less of 6 characters" do
+    expect(@user_without_strong_password.save).to be_falsey 
+  end
+  it "has a password with 6 characters" do
+    expect(@user_strong_password.save).to be_truthy 
+  end
+  it "has a true user role field by default" do
+    expect(@user_strong_password.user_role).to be_truthy 
+  end
+  it "has a true superadmin user role field" do
+    expect(@user_super_admin.superadmin_role).to be_truthy
+  end
+  it "has a true superadmin user role field and false user role field" do
+    expect(@user_no_user_role.user_role).to be_falsey
+  end
+  
 end


### PR DESCRIPTION

# Description
We need to add a field to implement the authorization functionality and avoid non admin users can register or create new users

 - What?: I've added a field role for user table to implement authorization. It includes
migration and tests.
 - Why?: These changes complete the user admin login creation experience which should create only once at creation database with migrations. 

 # Testing
 Run rspec command
