### PR TITLE
Add styles in admin login view

### DIFF
--- a/app/javascript/packs/applications.scss
+++ b/app/javascript/packs/applications.scss
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Oswald:wght@200;300;400;500;600;700&display=swap');
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";

--- a/app/views/application/_basic_layout.html.erb
+++ b/app/views/application/_basic_layout.html.erb
@@ -1,0 +1,3 @@
+<div class="container w-8/12  mx-auto max-w-screen-lg m-auto md:m-auto">
+    <%= yield :primary_content %>
+</div>

--- a/app/views/application/_full_layout.html.erb
+++ b/app/views/application/_full_layout.html.erb
@@ -1,0 +1,3 @@
+<div class="container w-full mx-auto max-w-screen-lg m-auto md:m-auto">
+    <%= yield :primary_content %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,46 @@
-<h2>Log in</h2>
+<% content_for :primary_content do %>
+  <div class="flex justify-center">
+    <div class=" shadow appearance-none border rounded py-4 md:py-16 px-9 md:px-48 text-gray-700 leading-tight focus:outline-none focus:shadow-outline flex flex-col">
+      <div class="font-sans font-semibold text-center m-2 text-2xl md:text-4xl md:pb-8">
+        <h2> ADMIN LOGIN</h2>
+      </div>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+      <div class="md:w-80">
+        <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+          <div class="field text-lg md:text-2xl">
+            <p class="my-2"><%= f.label :email %><br /></p>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email",
+              class:"h-10 md:text-xl md:h-14 w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline shadow appearance-none border text-center rounded",
+              placeholder:"Email"
+            %>
+          </div>
 
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
+          <div class="field text-lg	md:text-2xl">
+            <p class="my-2"><%= f.label :password %><br /></p>
+            <%= f.password_field :password, autocomplete: "current-password",
+              class:"h-10 md:text-xl md:h-14 w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline shadow appearance-none border text-center rounded",
+              placeholder:"Password"
+            %>
+          </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+          <% if devise_mapping.rememberable? %>
+            <div class="field my-4 md:text-xl">
+              <%= f.check_box :remember_me %>
+              <%= f.label :remember_me %>
+            </div>
+          <% end %>
+
+          <div class="actions my-4">
+            <%= f.submit "LOGIN",
+             class:" h-10 md:h-14 flex-shrink-0 bg-gray-900 hover:bg-gray-600 border-teal-500 hover:border-teal-700 text-sm md:text-xl w-full text-white py-1 px-2 rounded"
+            %>
+          </div>
+
+          <%= render "devise/shared/links"%>
+        <% end %>
+      </div>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
+<%end%>
 
-<%= render "devise/shared/links" %>
+<%=render 'full_layout'%>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Forgot your password?", new_password_path(resource_name), class:"my-4 font-light text-gray-600 md:text-lg  "  %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,7 @@
     <%= render 'layouts/partials/header' %>
     <%= render 'layouts/partials/alerts' %>
 
-    <main class="container mx-auto w-8/12 max-w-screen-lg m-auto md:m-auto">
-      <%= yield %>
-    </main>
+    <%= content_for?(:content) ? yield(:content) : yield %>
 
     <%= render 'layouts/partials/footer' %>
   </body>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -1,20 +1,22 @@
-<div class="sm:container mx-auto mt-5 flex flex-col md:flex-row-reverse md:justify-around md:items-center	md:flex">
-
-  <div class="md:flex md:flex-col md:w-2/5">
-    <div class="flex flex-col justify-center items-center md:h-32 md:bg-gray-900 md:rounded-md md:flex-row md:p-4">
-      <%= render_svg 'clock', styles:'text-blue-400 h-24 w-24' %>
-      <div class=" flex flex-col justify-center md:text-white md:flex-col-reverse md:ml-2.5">
-        <span class="text-4xl"><%=Time.now.strftime("%H:%M") %> </span>
-        <span> <%=Time.now.strftime("%A") %> </span>
+<% content_for :primary_content do %>
+  <div class="sm:container mx-auto mt-5 flex flex-col md:flex-row-reverse md:justify-around md:items-center	md:flex">
+    <div class="md:flex md:flex-col md:w-2/5">
+      <div class="flex flex-col justify-center items-center md:h-32 md:bg-gray-900 md:rounded-md md:flex-row md:p-4">
+        <%= render_svg 'clock', styles:'text-blue-400 h-24 w-24' %>
+        <div class=" flex flex-col justify-center md:text-white md:flex-col-reverse md:ml-2.5">
+          <span class="text-4xl"><%=Time.now.strftime("%H:%M") %> </span>
+          <span> <%=Time.now.strftime("%A") %> </span>
+        </div>
+      </div>
+      <div class="flex justify-center pt-4 md:block md:flex md:justify-center md:items-center md:bg-gray-900 md:h-32 md:mt-6 md:rounded-md md:p-4">
+        <%= render_svg 'check-mobile', styles:'w-96' %>
       </div>
     </div>
 
-    <div class="flex justify-center pt-4 md:block md:flex md:justify-center md:items-center md:bg-gray-900 md:h-32 md:mt-6 md:rounded-md md:p-4">
-      <%= render_svg 'check-mobile', styles:'w-96' %>
+    <div class=" w-12/12 text-center pb-3 my-5 md:bg-gray-900 md:flex md:items-center md:justify-center md:w-2/4 md:h-72 md:rounded-md md:my-0 md:p-6">
+      <%= react_component("App", { authenticity_token: form_authenticity_token  }) %>
     </div>
   </div>
+<%end%>
 
-  <div class=" w-12/12 text-center pb-3 my-5 md:bg-gray-900 md:flex md:items-center md:justify-center md:w-2/4 md:h-72 md:rounded-md md:my-0 md:p-6">
-    <%= react_component("App", { authenticity_token: form_authenticity_token  }) %>
-  </div>
-</div>
+<%=render 'basic_layout'%>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -240,6 +240,7 @@ module.exports = {
     },
     fontFamily: {
       sans: [
+        'Oswald',
         'ui-sans-serif',
         'system-ui',
         '-apple-system',


### PR DESCRIPTION
# Description
 - Added admin login styles to desktop and mobile view.
 - Added Oswald font family.
 - Update for admin user login view and main view in / views / application folder.

# What?
I added the styles we require for the admin view.

# Why?
These changes are necessary because the styles were added directly to the index layout and the login layout, as well as the font family that the project requires to make the application more user-friendly.

 # Test
can test it seeing the admin login path.

## Screenshots

- Desktop

![LOGIN-DESKTOP](https://user-images.githubusercontent.com/50384228/137008964-0bc4b5b6-e806-4232-8383-69121aa469b9.png)


- Mobile
![LOGIN-M](https://user-images.githubusercontent.com/50384228/137009239-2bcfe734-ed2c-41fb-81a0-f4a85007f913.png)


