### PR TITLE
Remove field id_user in attendances scaffolding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'react-rails', '~> 2.6', '>= 2.6.1'
 gem 'inline_svg'
 
 gem 'paranoia'
-gem 'cancancan' 
+gem 'cancancan'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 gem 'devise'
@@ -32,9 +32,10 @@ gem 'devise'
 gem 'bootsnap', '>= 1.4.4', require: false
 
 group :development, :test do
+  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'rspec-rails'
   gem 'dotenv-rails'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   # Use rubocop as the app server
   gem 'rubocop', require: false
   gem 'rubycritic', require: false
@@ -59,7 +60,7 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of web drivers to run system tests with browsers
   gem 'webdrivers'
-  gem 'rspec-rails'
+  gem 'shoulda-matchers', '~> 5.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,8 @@ GEM
       rubyzip (>= 1.2.2)
     semantic_range (3.0.0)
     sexp_processor (4.15.3)
+    shoulda-matchers (5.0.0)
+      activesupport (>= 5.2.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -360,6 +362,7 @@ DEPENDENCIES
   rubycritic
   sass-rails (>= 6)
   selenium-webdriver
+  shoulda-matchers (~> 5.0)
   spring
   turbolinks (~> 5)
   tzinfo-data

--- a/app/controllers/attendances_controller.rb
+++ b/app/controllers/attendances_controller.rb
@@ -66,6 +66,6 @@ class AttendancesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def attendance_params
-      params.require(:attendance).permit(:check_in, :check_out, :employee_id, :user_id)
+      params.require(:attendance).permit(:check_in, :check_out, :employee_id)
     end
 end

--- a/app/helpers/attendances_helper.rb
+++ b/app/helpers/attendances_helper.rb
@@ -1,9 +1,4 @@
 module AttendancesHelper
-    def assign_user(attendance, creator)
-        attendance.user = creator
-        attendance
-    end
-
     def assign_employee(attendance, creator)
         attendance.employee = creator
         attendance

--- a/app/helpers/employees_helper.rb
+++ b/app/helpers/employees_helper.rb
@@ -1,6 +1,6 @@
-module EmployeesHelper 
-    def assign_employee_creator(employee, creator)
-        employee.user = creator 
-        employee
-    end
+module EmployeesHelper
+  def assign_employee_creator(employee, creator)
+    employee.user = creator
+    employee
+  end
 end

--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,7 +1,7 @@
 class Attendance < ApplicationRecord
   attr_accessor :set_check_out
   belongs_to :employee
-  belongs_to :user
+
   before_create :set_check_in
   def set_check_in
     self.check_in = Time.now

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -7,5 +7,6 @@ class Employee < ApplicationRecord
 
   def self.find_by_number(private_number)
     employee = self.find_by(private_number: private_number)
+    employee
   end
 end

--- a/app/views/attendances/_attendance.json.jbuilder
+++ b/app/views/attendances/_attendance.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! attendance, :id, :check_in, :check_out, :employee_id, :user_id, :created_at, :updated_at
+json.extract! attendance, :id, :check_in, :check_out, :employee_id, :created_at, :updated_at
 json.url attendance_url(attendance, format: :json)

--- a/app/views/attendances/_form.html.erb
+++ b/app/views/attendances/_form.html.erb
@@ -26,11 +26,6 @@
     <%= form.text_field :employee_id %>
   </div>
 
-  <div class="field">
-    <%= form.label :user_id %>
-    <%= form.text_field :user_id %>
-  </div>
-
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/attendances/index.html.erb
+++ b/app/views/attendances/index.html.erb
@@ -8,7 +8,6 @@
       <th>Check in</th>
       <th>Check out</th>
       <th>Employee</th>
-      <th>User</th>
       <th colspan="3"></th>
     </tr>
   </thead>
@@ -19,7 +18,6 @@
         <td><%= attendance.check_in %></td>
         <td><%= attendance.check_out %></td>
         <td><%= attendance.employee_id %></td>
-        <td><%= attendance.user_id %></td>
         <td><%= link_to 'Show', attendance %></td>
         <td><%= link_to 'Edit', edit_attendance_path(attendance) %></td>
         <td><%= link_to 'Destroy', attendance, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/attendances/show.html.erb
+++ b/app/views/attendances/show.html.erb
@@ -15,10 +15,5 @@
   <%= @attendance.employee_id %>
 </p>
 
-<p>
-  <strong>User:</strong>
-  <%= @attendance.user_id %>
-</p>
-
 <%= link_to 'Edit', edit_attendance_path(@attendance) %> |
 <%= link_to 'Back', attendances_path %>

--- a/db/migrate/20211015005215_create_attendances.rb
+++ b/db/migrate/20211015005215_create_attendances.rb
@@ -4,7 +4,6 @@ class CreateAttendances < ActiveRecord::Migration[6.1]
       t.timestamp :check_in
       t.timestamp :check_out, default: nil
       t.references :employee, null: false, foreign_key: true
-      t.references :user, null: false, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20211025233428_remove_user_id_from_attendances.rb
+++ b/db/migrate/20211025233428_remove_user_id_from_attendances.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromAttendances < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :attendances, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_15_005215) do
+ActiveRecord::Schema.define(version: 2021_10_25_233428) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,11 +19,9 @@ ActiveRecord::Schema.define(version: 2021_10_15_005215) do
     t.datetime "check_in"
     t.datetime "check_out"
     t.bigint "employee_id", null: false
-    t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["employee_id"], name: "index_attendances_on_employee_id"
-    t.index ["user_id"], name: "index_attendances_on_user_id"
   end
 
   create_table "companies", force: :cascade do |t|
@@ -66,7 +64,6 @@ ActiveRecord::Schema.define(version: 2021_10_15_005215) do
   end
 
   add_foreign_key "attendances", "employees"
-  add_foreign_key "attendances", "users"
   add_foreign_key "companies", "users"
   add_foreign_key "employees", "users"
 end

--- a/spec/controllers/attendance_controller_spec.rb
+++ b/spec/controllers/attendance_controller_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe AttendancesController, type: :controller do
+  let(:attendance) { FactoryBot.create(:attendance) }
+  let(:employee) { FactoryBot.create( :employee ) }
+
+  describe 'POST create' do
+    subject { post :create, params: { attendance: attributes}  }
+
+    context 'with valid params' do
+      let(:attributes) { attributes_for(:attendance, employee_id: employee.id) }
+      it 'Creates new attendance' do
+        expect{ subject }.to change(Attendance, :count).by(1)
+      end
+
+      it 'redirect to attendance is successful with the notice' do
+        expect(subject).to redirect_to(Attendance.last)
+        expect(flash[:notice]).to be_present
+      end
+    end
+
+    context 'with invalid params' do
+      let(:attributes) { attributes_for(:attendance, employee_id: nil) }
+
+      it "It doesn't create new attendance" do
+        expect(response).to be_successful
+      end
+    end
+  end
+
+
+  context 'when employee is valid' do
+    it 'should check-out be nil' do
+      attendance.save
+      expect(attendance.check_out).to be_nil
+    end
+
+    it 'should check-in not be nil' do
+      attendance.save
+      expect(attendance.check_in).to_not be_nil
+    end
+
+    it 'should exist attendence for an employee' do
+      attendance_for_employee = Attendance.find_by_employee(employee.id)
+      expect(attendance_for_employee).to be_nil
+    end
+
+    it 'should not exist attendence for an employee' do
+      id = 102
+      attendance_for_employee_finded = Attendance.find_by_employee(id)
+      expect(attendance_for_employee_finded).to be_nil
+    end
+  end
+
+end

--- a/spec/factories/attendances.rb
+++ b/spec/factories/attendances.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :attendance do
+    employee
+    check_in{Faker::Time}
+    check_out{Faker::Time}
+  end
+end

--- a/spec/factories/employees.rb
+++ b/spec/factories/employees.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :employee do
+    user
+    name{Faker::Name.name}
+    email{Faker::Internet.email}
+    private_number{Faker::Number.number(digits: 5)}
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :user do
+    email{Faker::Internet.email}
+    password{Faker::Internet.password}
+
+    factory :superadmin_user do
+      superadmin_role{true}
+      user_role{false}
+    end
+
+    factory :regular_user do
+      superadmin_role{false}
+      user_role{true}
+    end
+  end
+end

--- a/spec/models/attendance_spec.rb
+++ b/spec/models/attendance_spec.rb
@@ -1,55 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Attendance, type: :model do
-  let(:user) { User.create(email:'dumy2@example.com', password:'1234567', superadmin_role: true, user_role: false) }
-  let(:employee) { Employee.create(name: 'Jose Estrada', email:'dumy2@example.com', private_number: 4125, user_id: user.id)  }
-  subject { Attendance.new( user_id: user.id) }
+  let(:attendance) { FactoryBot.create(:attendance) }
+  let(:employee) { FactoryBot.create( :employee ) }
 
-  before :each do
-    wrong_private_number = 4122
-    private_number = employee.private_number
-    @employee_finded = Employee.find_by_number(private_number)
-    @employee_not_finded = Employee.find_by_number(wrong_private_number)
-  end
-
-  it 'employee should exist for attendance creation' do
-    subject.employee_id = nil
-    subject.save
-    expect(subject).to_not be_valid
-  end
-
-  it 'should create attendance with employee private number' do
-    attendance = Attendance.create( user_id: user.id, employee: @employee_finded )
-    attendance.save
-    expect(attendance).to be_valid
-  end
-
-  it 'should create attendance with employee private number' do
-    attendance = Attendance.create( user_id: user.id, employee: @employee_not_finded )
-    attendance.save
-    expect(attendance).to_not be_valid
-  end
-
-  it 'should check-out be nil' do
-    attendance = Attendance.create( user_id: user.id, employee: @employee_finded )
-    attendance.save
-    expect(attendance.check_out).to be_nil
-  end
-
-  it 'should check-in not be nil' do
-    attendance = Attendance.create( user_id: user.id, employee: @employee_finded )
-    attendance.save
-    expect(attendance.check_in).to_not be_nil
-  end
-
-  it 'should exist attendence for an employee' do
-    attendance_for_employee_finded = Attendance.find_by_employee(@employee_finded.id)
-    expect(attendance_for_employee_finded).to be_nil
-  end
-
-  it 'should not exist attendence for an employee' do
-    id = 102
-    attendance_for_employee_finded = Attendance.find_by_employee(id)
-    expect(attendance_for_employee_finded).to be_nil
+  describe 'associations' do
+    it { should belong_to(:employee) }
   end
 end

--- a/spec/models/employee_spec.rb
+++ b/spec/models/employee_spec.rb
@@ -1,7 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe Employee, type: :model do
-  
+  describe 'associations' do
+    it { should belong_to(:user) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:email) }
+    it { should validate_presence_of(:private_number) }
+  end
+
   let(:user) { User.create(email:'dumy2@example.com', password:'1234567', superadmin_role: true, user_role: false) }
   subject { Employee.new(name: 'Jose Estrada', email:'dumy@example.com', private_number: 4123, user_id: user.id) }
   before :each do 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,9 +31,10 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  # require 'support/factory_bot'
+  config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
@@ -62,4 +63,11 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include Devise::Test::IntegrationHelpers, type: :request
+end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,4 @@
+# spec/support/factory_bot.rb
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
# Description
   - This feature removes the user_id model, which is not necessary for our assists logic to work.
   - To carry it out we need to change the logic of the tests, because we add the shoulda-matchers gems.
   - I have used two gems factory-rails-bot and faker to create information for testing.
   - I used Faker to get random information about jobs and attendances. 
    
   # Test
   These changes can be tested in the folder specifically specified in the driver folder and the models folder to assist