### PR TITLE
Add file to remove user_id from heroku databases

### DIFF
--- a/db/migrate/20211025233428_remove_user_id_from_attendances.rb
+++ b/db/migrate/20211025233428_remove_user_id_from_attendances.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromAttendances < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :attendances, :user, foreign_key: true
+  end
+end


### PR DESCRIPTION
# Description
 - This file are crated to run migrations in heroku and remove `user_id` field